### PR TITLE
Update ConsignmentSchema.json

### DIFF
--- a/ConsignmentSchema.json
+++ b/ConsignmentSchema.json
@@ -100,7 +100,7 @@
 							}
 						},
 						"uniqueItems": true,
-						"required": [ "analysisType", "procedureId", "standardProcedureCode" ]
+						"required": [ "analysisType", "procedureId", "standardProcedureCode", "uom" ]
 					}
 				}
 			},


### PR DESCRIPTION
Make uom mandatory on a result.
Forcing the provision of the uom allows verification that the uom used matches the uom of the procedure and helps establish that all results are in the same units.

Solution to #3 